### PR TITLE
Enable runtime environment configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 FROM node:18-alpine AS build
 WORKDIR /app
 COPY package*.json ./
-COPY .env .
 RUN npm ci
 COPY . .
 RUN npm run build
@@ -11,6 +10,8 @@ RUN npm run build
 FROM node:18-alpine
 WORKDIR /app
 RUN npm install -g serve
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY --from=build /app/dist ./dist
 EXPOSE 3000
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["serve", "-s", "dist", "-l", "3000"]

--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@ docker run -p 3000:3000 ollama-chatbot
 
 The frontend expects a backend available at `http://localhost:8080/api/ask`.
 
+## Runtime configuration
+
+The container generates an `env.js` file at startup which exposes
+`VITE_API_URL` via `window.ENV`. Set the `VITE_API_URL` environment variable in
+your Kubernetes deployment to change the backend URL without rebuilding the
+image.
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+cat <<EOT > /app/dist/env.js
+window.ENV = {
+  VITE_API_URL: "${VITE_API_URL}"
+};
+EOT
+exec "$@"

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/env.js"></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/public/env.js
+++ b/public/env.js
@@ -1,0 +1,3 @@
+window.ENV = {
+  VITE_API_URL: 'http://localhost:8080'
+};

--- a/src/model/chatModel.js
+++ b/src/model/chatModel.js
@@ -1,5 +1,6 @@
 export async function askBackend(prompt) {
-  const response = await fetch(`${import.meta.env.VITE_API_URL}/api/ask`, {
+  const apiUrl = window.ENV?.VITE_API_URL || import.meta.env.VITE_API_URL;
+  const response = await fetch(`${apiUrl}/api/ask`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- generate env.js at container startup via an entrypoint script
- load env.js in `index.html`
- read the backend URL from `window.ENV`
- document how to set `VITE_API_URL`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68791865d2148321b02eeda200a83546